### PR TITLE
Directories sorted by Creation Time on the RcloneMount

### DIFF
--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -125,20 +125,21 @@ public class SymlinkDownloader : IDownloader
         // this creates symlinks fast, about 5seconds from unrestricting link
         private static FileInfo? TryGetFile(string Name)
         {
-            var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
+                var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
 
-        // Get the subdirectories sorted by creation date in descending order
-            var sortedDirectories = dirInfo.GetDirectories()
-                .OrderByDescending(d => d.CreationTime)
-                .ToList();
+            // Get the subdirectories sorted by creation date in descending order
+                var sortedDirectories = dirInfo.GetDirectories()
+                    .OrderByDescending(d => d.CreationTime)
+                    .ToList();
 
-        foreach (var dir in sortedDirectories)
-        {
-            var files = dir.EnumerateFiles();
-            var file = files.FirstOrDefault(f => f.Name == Name);
-            if (file != null) { return file; }
+            foreach (var dir in sortedDirectories)
+            {
+                var files = dir.EnumerateFiles();
+                var file = files.FirstOrDefault(f => f.Name == Name);
+                if (file != null) { return file; }
+            }
+            return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
         }
-        return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
 
     // private static FileInfo? TryGetFile(string Name)
     // {

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -122,16 +122,34 @@ public class SymlinkDownloader : IDownloader
         }
     }
 
-    private static FileInfo? TryGetFile(string Name)
-    {
-        var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
-        foreach (var dir in dirInfo.GetDirectories())
+        // this creates symlinks fast, about 5seconds from unrestricting link
+        private static FileInfo? TryGetFile(string Name)
+        {
+            var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
+
+        // Get the subdirectories sorted by creation date in descending order
+            var sortedDirectories = dirInfo.GetDirectories()
+                .OrderByDescending(d => d.CreationTime)
+                .ToList();
+
+        foreach (var dir in sortedDirectories)
         {
             var files = dir.EnumerateFiles();
             var file = files.FirstOrDefault(f => f.Name == Name);
             if (file != null) { return file; }
         }
         return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
-        //return Directory.GetFiles(Settings.Get.DownloadClient.RcloneMountPath, Name, SearchOption.AllDirectories);
-    }
+
+    // private static FileInfo? TryGetFile(string Name)
+    // {
+    //     var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
+    //     foreach (var dir in dirInfo.GetDirectories())
+    //     {
+    //         var files = dir.EnumerateFiles();
+    //         var file = files.FirstOrDefault(f => f.Name == Name);
+    //         if (file != null) { return file; }
+    //     }
+    //     return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
+    //     //return Directory.GetFiles(Settings.Get.DownloadClient.RcloneMountPath, Name, SearchOption.AllDirectories);
+    // }
 }

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -121,8 +121,6 @@ public class SymlinkDownloader : IDownloader
             return false;
         }
     }
-
-        // this creates symlinks fast, about 5seconds from unrestricting link
         private static FileInfo? TryGetFile(string Name)
         {
                 var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
@@ -140,17 +138,4 @@ public class SymlinkDownloader : IDownloader
             }
             return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
         }
-
-    // private static FileInfo? TryGetFile(string Name)
-    // {
-    //     var dirInfo = new DirectoryInfo(Settings.Get.DownloadClient.RcloneMountPath);
-    //     foreach (var dir in dirInfo.GetDirectories())
-    //     {
-    //         var files = dir.EnumerateFiles();
-    //         var file = files.FirstOrDefault(f => f.Name == Name);
-    //         if (file != null) { return file; }
-    //     }
-    //     return dirInfo.EnumerateFiles().FirstOrDefault(f => f.Name == Name);
-    //     //return Directory.GetFiles(Settings.Get.DownloadClient.RcloneMountPath, Name, SearchOption.AllDirectories);
-    // }
 }


### PR DESCRIPTION
Before searching the Rclone mount, it gets all directories to list in order of creation

After file selection, it takes about 5secs to create symlink.


is it possible for RDT to select files on a torrent based biggest file? so only select the biggest file?